### PR TITLE
update default type for countup num, following theme font style changes

### DIFF
--- a/meta-data/th-countup-num.json
+++ b/meta-data/th-countup-num.json
@@ -10,7 +10,7 @@
     "numberSize":{"friendly":"Number Size", "type":"int", "default":40}, 
     "growNumber":{"friendly":"Grow Number?", "type":"boolean", "default":"false"}, 
     "color":{"friendly":"Number Color", "type":"colorPicker", "default":"", "optional":true}, 
-    "type":{"friendly":"Type","type":"dropdown", "values": ["headline","mainpoint", "submainpoint", "subpoint", "chart", "label", "caps"], "default": "mainpoint"},
+    "type":{"friendly":"Type","type":"dropdown", "values": ["headline","mainpoint", "submainpoint", "subpoint", "chart", "label", "caps"], "default": "submainpoint"},
     "startFrom":{"friendly":"Start From", "type":"int", "default":0},
     "startFromSameNumberOfDigit":{"friendly":"Same number dig?", "type":"boolean", "default":"true"},
     "duration":{"friendly":"Duration", "type":"int", "default":2}

--- a/meta-data/th-text.json
+++ b/meta-data/th-text.json
@@ -23,7 +23,7 @@
     "highlighting":{
       "friendly":"Hightlighting",
       "type":"dropdown", 
-      "values": ["black", "white"],
+      "values": ["", "black", "white"],
       "default": ""
     },
     "markdown":{"friendly":"Markdown", "type":"boolean", "default":"true"},


### PR DESCRIPTION
This change has been made in response to the font style changes made in thelma-utils: https://github.com/thelmanews/thelma-utils/pull/1
